### PR TITLE
Limitação de PDF para Boleto Bancário e ajuste de escrita e versão

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Permite a emissão de boletos e integração do gateway da Paghiper ao seu WHMCS.
 Este módulo implementa emissão de boletos com retorno automático.
 
-* **Versão mais Recente:** 2.0
+* **Versão mais Recente:** 2.0.1
 * **Requer WHMCS** versão mínima 5.0
 * **Requisitos:** PHP >= 5.2.0, cURL ativado.
 * **Compatibilidade:** WHMCS 7.1.2, PHP 7.x. Mod_rewrite opcional

--- a/invoicepdf.tpl
+++ b/invoicepdf.tpl
@@ -18,7 +18,7 @@ $result = json_decode($json);
 $transaction_id = (isset($result->transaction_id)) ? $result->transaction_id : '';
 $pdf_url = (isset($result->bank_slip)) ? $result->bank_slip->url_slip_pdf : $result->url_slip_pdf;
 
-if ((in_array($status, array('Unpaid', 'Payment Pending'))) && (isset($pdf_url) && !empty($pdf_url)) && (isset($transaction_id) && !empty($transaction_id))){
+if ((in_array($status, array('Unpaid', 'Payment Pending'))) && (isset($pdf_url) && !empty($pdf_url)) && (isset($transaction_id) && !empty($transaction_id)) && (in_array($paymentmethod, array('Boleto Bancário')))){
 
     $basedir = dirname(__FILE__).'/../../modules/gateways/paghiper/';
 
@@ -56,3 +56,4 @@ if ((in_array($status, array('Unpaid', 'Payment Pending'))) && (isset($pdf_url) 
     $pdf->AddPage();
 
 }
+?>

--- a/modules/gateways/paghiper.php
+++ b/modules/gateways/paghiper.php
@@ -136,7 +136,7 @@ Sempre começa por apk_. Caso não tenha essa informação, pegue sua chave API 
                 '1'    => 'Sim',
                 '0'     => 'Não',
             ),
-            'Description' => 'Caso selecione não, boletos bancários e lihnas digitáveis serão selecionadas somente caso o cliente selecione "Boleto Bancário" (ou o nome que você configurar no primeiro campo de configuração) como método de pagamento padrão.',
+            'Description' => 'Caso selecione não, boletos bancários e linhas digitáveis serão selecionadas somente caso o cliente selecione "Boleto Bancário" (ou o nome que você configurar no primeiro campo de configuração) como método de pagamento padrão.',
         ),
         
         "admin" => array(

--- a/modules/gateways/paghiper.php
+++ b/modules/gateways/paghiper.php
@@ -211,7 +211,11 @@ function paghiper_link($params) {
     <input type='image' src='https://www.paghiper.com/img/checkout/boleto/boleto-240px-148px.jpg' 
     title='Pagar com Boleto' alt='Pagar com Boleto' border='0'
      align='absbottom' width='120' height='74' /><br>
-    <button class='btn btn-success' style='margin-top: 5px;' type=\"submit\"><i class='fa fa-barcode'></i> Gerar Boleto</button>
+    <button formtarget='_blank' class='btn btn-success' style='margin-top: 5px;' type=\"submit\"><i class='fa fa-barcode'></i> Gerar Boleto</button>
+    <br> <br>
+    <div class='alert alert-warning' role='alert'>
+    <strong>Importante:</strong> A compensação bancária poderá levar até 2 dias úteis.
+    </div>
     <!-- FIM DO BOLETO PAGHIPER -->
     </form>
     {$abrirAuto}";


### PR DESCRIPTION
@henriqueccruz 

Coloquei uma nova verificação dentro do arquivo "invoicepdf.tpl" para que ele envie o boleto em PDF somente para a forma de pagamento "Boleto Bancário", porém neste caso é necessário orientar aos usuários que troquem dentro do IF o nome para seu respectivo módulo, exemplo:

`if ((in_array($status, array('Unpaid', 'Payment Pending'))) && (isset($pdf_url) && !empty($pdf_url)) && (isset($transaction_id) && !empty($transaction_id)) && (in_array($paymentmethod, array('Boleto Bancário')))){`

Ainda sim está com um erro bem chato que não consegui arrumar, vamos lá...

Aqui por exemplo, oferecemos valores diferentes conforme o tipo de pagamento, ao criar a fatura com o método como "Boleto Bancário", ele gera a fatura via PagHiper normalmente, enviando o PDF para o cliente, porém se este cliente mudar a forma de pagamento, nos próximos e-mails de lembrete de pagamento de fatura, ele não receberá o PDF no e-mail, conforme este novo ajuste, porém é gerado um novo boleto na plataforma do PagHiper. Precisaria existir alguma limitação para acionasse a API para gerar o boleto, somente quando a fatura está como "Boleto Bancário", caso contrário, ficará gerando boletos de forma indevida, acha que consegue alguma solução para este caso? (Issue #40)

Arrumei também um erro ortográfico dentro do arquivo "paghiper.php" e ajustei a nova versão 2.0.1 que você lançou, dentro do arquivo "README.md".

Aguardo seu retorno.

Espero ter ajudado, forte abraço!